### PR TITLE
Implement overwrite

### DIFF
--- a/android/src/main/kotlin/com/derdilla/persistent_user_dir_access_android/PersistentUserDirAccessAndroidPlugin.kt
+++ b/android/src/main/kotlin/com/derdilla/persistent_user_dir_access_android/PersistentUserDirAccessAndroidPlugin.kt
@@ -103,20 +103,23 @@ class PersistentUserDirAccessAndroidPlugin: FlutterPlugin, MethodCallHandler, Ac
     val fileName = call.argument<String>("name")
     val mimeType = call.argument<String>("mime")
     val data = call.argument<ByteArray>("data")
-    if (dir == null || mimeType == null || fileName == null || data == null) {
+    val overwrite = call.argument<Boolean>("overwrite");
+    if (dir == null || mimeType == null || fileName == null || data == null || overwrite == null) {
       result.error("ArgErr", "Wrong writeFile arguments passed to native implementation", null)
       return
     }
 
     // Not compiled for older platform versions so true assert is fine
     val dirUri = DocumentFile.fromTreeUri(activity!!.activity.applicationContext, Uri.parse(dir))!!
-    val file = try {
-      dirUri.createFile(mimeType, fileName)
-    } catch (e: UnsupportedOperationException) {
-      result.error("IOErr", e.message, null)
-      return
-    }!!
-
+    
+    val file = (if (overwrite) dirUri.findFile(fileName) else null) 
+      ?: try {
+        dirUri.createFile(mimeType, fileName)
+      } catch (e: UnsupportedOperationException) {
+        result.error("IOErr", e.message, null)
+        return
+      }!!
+      
     // Open file to write. Existing content will be truncated
     try {
       activity!!.activity.contentResolver.openOutputStream(file.uri, "wt").use { stream ->

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -56,6 +56,22 @@ class _AppState extends State<App> {
                   );
                 },
         ),
+        ListTile(
+          title: const Text(
+            "writeFile(uri, 'test.txt', 'text/plain', utf8.encode('Overwrite test'), true)",
+          ),
+          onTap: _uri == null
+              ? null
+              : () async {
+                  await widget.userDirs.writeFile(
+                    _uri!,
+                    'test.txt',
+                    'text/plain',
+                    utf8.encode('Overwrite test'),
+                    true
+                  );
+                },
+        ),
       ],
     ),
   );

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -60,7 +60,7 @@ void main() {
     expect(plugin.methodInvokeHistory, hasLength(2));
     expect(
       plugin.methodInvokeHistory[1],
-      'writeFile(test://uri,test.txt,text/plain, [84, 101, 115, 116, 32, 116, 101, 120, 116])',
+      'writeFile(test://uri,test.txt,text/plain, [84, 101, 115, 116, 32, 116, 101, 120, 116], false)',
     );
   });
 }
@@ -83,8 +83,9 @@ class MockPersistentUserDirAccessAndroid
     String fileName,
     String mimeType,
     Uint8List data,
+    [bool overwrite = false]
   ) async {
-    methodInvokeHistory.add('writeFile($dirUri,$fileName,$mimeType, $data)');
+    methodInvokeHistory.add('writeFile($dirUri,$fileName,$mimeType, $data, $overwrite)');
     return writeFileResult;
   }
 }

--- a/lib/persistent_user_dir_access_android.dart
+++ b/lib/persistent_user_dir_access_android.dart
@@ -42,7 +42,7 @@ class PersistentUserDirAccessAndroid {
   ///
   /// Returns success state of the operation.
   Future<bool> writeFile(
-      String dirUri, String fileName, String mimeType, Uint8List data) async {
+      String dirUri, String fileName, String mimeType, Uint8List data, [bool overwrite = false]) async {
     try {
       final res =
           await _channel.invokeMethod<bool>('writeFile', <String, dynamic>{
@@ -50,6 +50,7 @@ class PersistentUserDirAccessAndroid {
         'name': fileName,
         'mime': mimeType,
         'data': data,
+        'overwrite': overwrite,
       });
       return res ?? false;
     } on PlatformException catch (e) {


### PR DESCRIPTION
Add an optional `overwrite` parameter to `writeFile`. If set to true, this allows overwriting existing files. If set to false (default), a new file will be created by the OS, if the file name already exists.

The example application is updated to have  a new button to overwrite the created test file.

See: https://github.com/derdilla/blood-pressure-monitor-fl/pull/711